### PR TITLE
Fix RemoteHelper url on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # client-mock-node
-A very dumb client implementation for testing the [RemoteHelper](remote-helper), in Node.js.
+A very dumb client implementation for testing the [RemoteHelper](https://github.com/RemoteHelper/server), in Node.js.
 
 ## Usage
 This client implements 
-a simple use case of the [RemoteHelper](remote-helper). 
+a simple use case of the [RemoteHelper](https://github.com/RemoteHelper/server). 
 For it to work properly, 
-the [RemoteHelper](remote-helper) must already be running.
+the [RemoteHelper](https://github.com/RemoteHelper/server) must already be running.
 
 You can configure where this client
-is supposed to look for the [RemoteHelper](remote-helper)
+is supposed to look for the [RemoteHelper](https://github.com/RemoteHelper/server)
 in [the config file](./config.json).
 
 Start the client by running
 `node server.js`.
 This will create an HTTP server
-which receives events from the [RemoteHelper](remote-helper)
+which receives events from the [RemoteHelper](https://github.com/RemoteHelper/server)
 and responds to them,
 and it will also issue an image help request
 to the RemoteHelper.
@@ -23,13 +23,10 @@ The use case implemented is the following:
 the client listens for a total of 10 events
 (for instance, 5 mouse clicks --
 each one triggers `mouseup` and `mousedown`)
-and then tells the [RemoteHelper](remote-helper)
+and then tells the [RemoteHelper](https://github.com/RemoteHelper/server)
 that the help job is done.
 In addition, for `mouseup` events,
 if the click is on the upper-right side
 of the screen,
 it sends a new `mediaURL` (a new image)
-for the [RemoteHelper](remote-helper) to update the static page. 
-
-
-[remote-helper]: https://github.com/RemoteHelper/server
+for the [RemoteHelper](https://github.com/RemoteHelper/server) to update the static page. 


### PR DESCRIPTION
Old way of referencing the url didn't work and would point to an invalid
address instead:

https://github.com/RemoteHelper/client-mock-node/blob/master/remote-helper
